### PR TITLE
No need to declare a default in code if a default is declared in step.yml

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-
-
-
 # Required parameters
 if [ -z "${input_file}" ] ; then
   echo " [!] Missing required input: input_file"
@@ -18,10 +15,6 @@ fi
 if [ -z "${output_file}" ] ; then
   echo " [!] Missing required input: output_file"
   exit 1
-fi
-
-if [ -z "${move_action}" ] ; then
-    move_action = "false"
 fi
 
 echo "This is the value specified for the input 'input_file': ${input_file}"


### PR DESCRIPTION
When the step runs through the CLI and there's a default specified in `step.yml` then that will be used.

But even if you want to keep this (you of course can if you want to, this is just a suggestion) you should use one of the values from `step.yml` (copy or move) not "false" ;)